### PR TITLE
Fixed a couple of issues with strict types

### DIFF
--- a/src/specter/network/SpecterInterface.php
+++ b/src/specter/network/SpecterInterface.php
@@ -179,7 +179,7 @@ class SpecterInterface implements SourceInterface{
             $pk->clientId = 1;
             $pk->identityPublicKey = "key here";
             $pk->skin = str_repeat("\x80", 64 * 32 * 4);
-            $pk->skinId = 1;
+            $pk->skinId = "Standard_Alex";
 
             $pk->handle($player);
 

--- a/src/specter/network/SpecterInterface.php
+++ b/src/specter/network/SpecterInterface.php
@@ -175,7 +175,7 @@ class SpecterInterface implements SourceInterface{
             $pk->username = $username;
             $pk->gameEdition = 0;
             $pk->protocol = ProtocolInfo::CURRENT_PROTOCOL;
-            $pk->clientUUID = UUID::fromData($address, $port, $username);
+            $pk->clientUUID = UUID::fromData($address, $port, $username)->toString();
             $pk->clientId = 1;
             $pk->identityPublicKey = "key here";
             $pk->skin = str_repeat("\x80", 64 * 32 * 4);


### PR DESCRIPTION
- skin ID should be a string, not an int. This would previously have silently caused unexpected behaviour, but as of latest commits to PMMP master strict types raise errors about this.
- clientUUID should be a string, you were giving it a UUID object.