### PR TITLE
Fixed passing null by default to Player::__construct()

### DIFF
--- a/src/specter/api/DummyPlayer.php
+++ b/src/specter/api/DummyPlayer.php
@@ -7,7 +7,7 @@ use specter\Specter;
 
 class DummyPlayer{
     private $server;
-    public function __construct($name, $address = null, $port = null, Server $server = null){
+    public function __construct($name, $address = "SPECTER", $port = 19133, Server $server = null){
         $this->name = $name;
         $this->server = $server === null ? Server::getInstance() : $server;
         if(!$this->getSpecter()->getInterface()->openSession($name, $address, $port)){


### PR DESCRIPTION
This causes problems since strict types update