### PR TITLE
Exception fix

### DIFF
--- a/src/specter/network/SpecterInterface.php
+++ b/src/specter/network/SpecterInterface.php
@@ -192,6 +192,7 @@ class SpecterInterface implements SourceInterface{
             $pk->protocol = ProtocolInfo::CURRENT_PROTOCOL;
             $pk->clientUUID = UUID::fromData($address, $port, $username)->toString();
             $pk->clientId = 1;
+	     $pk->xuid = "xuid here";
             $pk->identityPublicKey = "key here";
             $pk->clientData["SkinId"] = "Specter";
             $pk->clientData["SkinData"] = base64_encode(str_repeat("\x80", 64 * 32 * 4));


### PR DESCRIPTION
This PR fixes this exception:
` Unhandled exception executing command 's s test' in specter: Return value of pocketmine\Player::getXuid() must be of the type string, null returned`